### PR TITLE
Move map data into backtrace data proper.

### DIFF
--- a/debuggerd/tombstone.cpp
+++ b/debuggerd/tombstone.cpp
@@ -239,13 +239,12 @@ static void dump_stack_segment(
       break;
     }
 
-    backtrace_map_t map;
-    backtrace->FillInMap(stack_content, &map);
+    const backtrace_map_t* map = backtrace->FindMap(stack_content);
     const char* map_name;
-    if (BacktraceMap::IsValid(map)) {
+    if (!map) {
       map_name = "";
     } else {
-      map_name = map.name.c_str();
+      map_name = map->name.c_str();
     }
     uintptr_t offset = 0;
     std::string func_name(backtrace->GetFunctionName(stack_content, &offset));

--- a/include/backtrace/Backtrace.h
+++ b/include/backtrace/Backtrace.h
@@ -39,7 +39,7 @@ struct backtrace_frame_data_t {
   uintptr_t pc;           // The absolute pc.
   uintptr_t sp;           // The top of the stack.
   size_t stack_size;      // The size of the stack, zero indicate an unknown stack size.
-  backtrace_map_t map;    // The map associated with the given pc.
+  const backtrace_map_t* map;   // The map associated with the given pc.
   std::string func_name;  // The function name associated with this pc, NULL if not found.
   uintptr_t func_offset;  // pc relative to the start of the function, only valid if func_name is not NULL.
 };
@@ -78,8 +78,8 @@ public:
   // If the string is empty, then no valid function name was found.
   virtual std::string GetFunctionName(uintptr_t pc, uintptr_t* offset);
 
-  // Fill in the map data associated with the given pc.
-  virtual void FillInMap(uintptr_t pc, backtrace_map_t* map);
+  // Find the map associated with the given pc.
+  virtual const backtrace_map_t* FindMap(uintptr_t pc);
 
   // Read the data at a specific address.
   virtual bool ReadWord(uintptr_t ptr, word_t* out_value) = 0;

--- a/include/backtrace/BacktraceMap.h
+++ b/include/backtrace/BacktraceMap.h
@@ -33,8 +33,6 @@
 #include <string>
 
 struct backtrace_map_t {
-  backtrace_map_t(): start(0), end(0), flags(0) {}
-
   uintptr_t start;
   uintptr_t end;
   int flags;
@@ -50,16 +48,15 @@ public:
 
   virtual ~BacktraceMap();
 
-  // Fill in the map data structure for the given address.
-  virtual void FillIn(uintptr_t addr, backtrace_map_t* map);
+  // Get the map data structure for the given address.
+  virtual const backtrace_map_t* Find(uintptr_t addr);
 
   // The flags returned are the same flags as used by the mmap call.
   // The values are PROT_*.
   int GetFlags(uintptr_t pc) {
-    backtrace_map_t map;
-    FillIn(pc, &map);
-    if (IsValid(map)) {
-      return map.flags;
+    const backtrace_map_t* map = Find(pc);
+    if (map) {
+      return map->flags;
     }
     return PROT_NONE;
   }
@@ -77,10 +74,6 @@ public:
   const_iterator end() const { return maps_.end(); }
 
   virtual bool Build();
-
-  static inline bool IsValid(const backtrace_map_t& map) {
-    return map.end > 0;
-  }
 
 protected:
   BacktraceMap(pid_t pid);

--- a/libbacktrace/BacktraceImpl.cpp
+++ b/libbacktrace/BacktraceImpl.cpp
@@ -99,15 +99,15 @@ std::string Backtrace::FormatFrameData(size_t frame_num) {
 
 std::string Backtrace::FormatFrameData(const backtrace_frame_data_t* frame) {
   const char* map_name;
-  if (BacktraceMap::IsValid(frame->map) && !frame->map.name.empty()) {
-    map_name = frame->map.name.c_str();
+  if (frame->map && !frame->map->name.empty()) {
+    map_name = frame->map->name.c_str();
   } else {
     map_name = "<unknown>";
   }
 
   uintptr_t relative_pc;
-  if (BacktraceMap::IsValid(frame->map)) {
-    relative_pc = frame->pc - frame->map.start;
+  if (frame->map) {
+    relative_pc = frame->pc - frame->map->start;
   } else {
     relative_pc = frame->pc;
   }
@@ -128,8 +128,8 @@ std::string Backtrace::FormatFrameData(const backtrace_frame_data_t* frame) {
   return buf;
 }
 
-void Backtrace::FillInMap(uintptr_t pc, backtrace_map_t* map) {
-  map_->FillIn(pc, map);
+const backtrace_map_t* Backtrace::FindMap(uintptr_t pc) {
+  return map_->Find(pc);
 }
 
 //-------------------------------------------------------------------------
@@ -147,9 +147,8 @@ bool BacktraceCurrent::ReadWord(uintptr_t ptr, word_t* out_value) {
     return false;
   }
 
-  backtrace_map_t map;
-  FillInMap(ptr, &map);
-  if (BacktraceMap::IsValid(map) && map.flags & PROT_READ) {
+  const backtrace_map_t* map = FindMap(ptr);
+  if (map && map->flags & PROT_READ) {
     *out_value = *reinterpret_cast<word_t*>(ptr);
     return true;
   } else {

--- a/libbacktrace/BacktraceImpl.h
+++ b/libbacktrace/BacktraceImpl.h
@@ -37,8 +37,8 @@ public:
   inline pid_t Pid() { return backtrace_obj_->Pid(); }
   inline pid_t Tid() { return backtrace_obj_->Tid(); }
 
-  inline void FillInMap(uintptr_t addr, backtrace_map_t* map) {
-    backtrace_obj_->FillInMap(addr, map);
+  inline const backtrace_map_t* FindMap(uintptr_t addr) {
+    return backtrace_obj_->FindMap(addr);
   }
   inline std::string GetFunctionName(uintptr_t pc, uintptr_t* offset) {
     return backtrace_obj_->GetFunctionName(pc, offset);

--- a/libbacktrace/BacktraceMap.cpp
+++ b/libbacktrace/BacktraceMap.cpp
@@ -37,15 +37,14 @@ BacktraceMap::BacktraceMap(pid_t pid) : pid_(pid) {
 BacktraceMap::~BacktraceMap() {
 }
 
-void BacktraceMap::FillIn(uintptr_t addr, backtrace_map_t* map) {
+const backtrace_map_t* BacktraceMap::Find(uintptr_t addr) {
   for (BacktraceMap::const_iterator it = begin();
        it != end(); ++it) {
     if (addr >= it->start && addr < it->end) {
-      *map = *it;
-      return;
+      return &*it;
     }
   }
-  *map = {};
+  return NULL;
 }
 
 bool BacktraceMap::ParseLine(const char* line, backtrace_map_t* map) {

--- a/libbacktrace/UnwindCurrent.cpp
+++ b/libbacktrace/UnwindCurrent.cpp
@@ -137,8 +137,9 @@ bool UnwindCurrent::UnwindFromContext(size_t num_ignore_frames, bool within_hand
 
       if (!within_handler) {
         frame->func_name = GetFunctionName(frame->pc, &frame->func_offset);
-        FillInMap(frame->pc, &frame->map);
+        frame->map = FindMap(frame->pc);
       } else {
+        frame->map = NULL;
         frame->func_offset = 0;
       }
       num_frames++;

--- a/libbacktrace/UnwindMap.cpp
+++ b/libbacktrace/UnwindMap.cpp
@@ -113,17 +113,18 @@ bool UnwindMapLocal::Build() {
   return (map_created_ = (unw_map_local_create() == 0)) && GenerateMap();;
 }
 
-void UnwindMapLocal::FillIn(uintptr_t addr, backtrace_map_t* map) {
-  BacktraceMap::FillIn(addr, map);
-  if (!IsValid(*map)) {
+const backtrace_map_t* UnwindMapLocal::Find(uintptr_t addr) {
+  const backtrace_map_t* map = BacktraceMap::Find(addr);
+  if (!map) {
     // Check to see if the underlying map changed and regenerate the map
     // if it did.
     if (unw_map_local_cursor_valid(&map_cursor_) < 0) {
       if (GenerateMap()) {
-        BacktraceMap::FillIn(addr, map);
+        map = BacktraceMap::Find(addr);
       }
     }
   }
+  return map;
 }
 
 //-------------------------------------------------------------------------

--- a/libbacktrace/UnwindMap.h
+++ b/libbacktrace/UnwindMap.h
@@ -45,7 +45,7 @@ public:
 
   virtual bool Build();
 
-  virtual void FillIn(uintptr_t addr, backtrace_map_t* map);
+  virtual const backtrace_map_t* Find(uintptr_t addr);
 
 protected:
   virtual bool GenerateMap();

--- a/libbacktrace/UnwindPtrace.cpp
+++ b/libbacktrace/UnwindPtrace.cpp
@@ -106,7 +106,7 @@ bool UnwindPtrace::Unwind(size_t num_ignore_frames, ucontext_t* ucontext) {
 
       frame->func_name = GetFunctionName(frame->pc, &frame->func_offset);
 
-      FillInMap(frame->pc, &frame->map);
+      frame->map = FindMap(frame->pc);
 
       num_frames++;
     } else {

--- a/libbacktrace/backtrace_test.cpp
+++ b/libbacktrace/backtrace_test.cpp
@@ -681,25 +681,6 @@ TEST(libbacktrace, simultaneous_maps) {
   delete map3;
 }
 
-TEST(libbacktrace, fillin_erases) {
-  BacktraceMap* back_map = BacktraceMap::Create(getpid());
-
-  backtrace_map_t map;
-
-  map.start = 1;
-  map.end = 3;
-  map.flags = 1;
-  map.name = "Initialized";
-  back_map->FillIn(0, &map);
-  delete back_map;
-
-  ASSERT_FALSE(BacktraceMap::IsValid(map));
-  ASSERT_EQ(static_cast<uintptr_t>(0), map.start);
-  ASSERT_EQ(static_cast<uintptr_t>(0), map.end);
-  ASSERT_EQ(0, map.flags);
-  ASSERT_EQ("", map.name);
-}
-
 TEST(libbacktrace, format_test) {
   UniquePtr<Backtrace> backtrace(Backtrace::Create(getpid(), BACKTRACE_CURRENT_THREAD));
   ASSERT_TRUE(backtrace.get() != NULL);
@@ -709,7 +690,12 @@ TEST(libbacktrace, format_test) {
   frame.pc = 2;
   frame.sp = 0;
   frame.stack_size = 0;
+  frame.map = NULL;
   frame.func_offset = 0;
+
+  backtrace_map_t map;
+  map.start = 0;
+  map.end = 0;
 
   // Check no map set.
   frame.num = 1;
@@ -721,8 +707,8 @@ TEST(libbacktrace, format_test) {
             backtrace->FormatFrameData(&frame));
 
   // Check map name empty, but exists.
-  frame.map.start = 1;
-  frame.map.end = 1;
+  frame.map = &map;
+  map.start = 1;
 #if defined(__LP64__)
   EXPECT_EQ("#01 pc 0000000000000001  <unknown>",
 #else
@@ -733,9 +719,9 @@ TEST(libbacktrace, format_test) {
 
   // Check relative pc is set and map name is set.
   frame.pc = 0x12345679;
-  frame.map.name = "MapFake";
-  frame.map.start =  1;
-  frame.map.end =  1;
+  frame.map = &map;
+  map.name = "MapFake";
+  map.start =  1;
 #if defined(__LP64__)
   EXPECT_EQ("#01 pc 0000000012345678  MapFake",
 #else


### PR DESCRIPTION
The backtrace structure used to include a pointer to a backtrace_map_t
that represented the map data for a particular pc. This introduced a
race condition where the pointer could be discarded, but the backtrace
structure still contained a pointer to garbage memory. Now all of the map
information is right in the structure.

Bug: 19028453
Change-Id: If7088a73f3c6bf1f3bc8cdd2bb4b62e7cab831c0
Signed-off-by: Chet Kener Cl3Kener@gmail.com (reverted from commit d155a731a4595f67a940e3b0cbad977133fb4fc0)
